### PR TITLE
58: Allow multiple blueprints to be specified in  clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,34 @@ Stages:
         WriteCapacityUnits:     100
 ```
 
+You can also extend your stack configuration by using multiple blueprints, like this:
+
+```yaml
+  Version: 2
+  Blueprints:
+    BaseDDB:
+      Template:          https://s3.amazonaws.com/cloudformation-templates-us-east-1/DynamoDB_Table.template
+      Parameters:
+        ReadCapacityUnits:      5
+        WriteCapacityUnits:     5
+        HashKeyElementName:     id
+    ProdOverrides:
+      Parameters:
+        ReadCapacityUnits:      100
+        WriteCapacityUnits:     100
+      
+  ...
+
+  Prod:
+    Stack1:
+      Extends:           [ BaseDDB, ProdOverrides ]
+      Region:            us-east-1
+      Profile:           prod
+      StackName:         DDB
+  
+  ... 
+  ```
+
 For details about rules of how parameters are extended, please see the
 following chapter `Config Inheritance`.
 
@@ -365,7 +393,8 @@ Stages:
       ResourceTypes:
         - AWS::EC2
 ```
-4. Special Case List:
+4. If multiple blueprints are specified in `Extends` clause, they are applied in order of appearance.
+5. Special Case List:
 
     Capabilities: Replace the original value.
 

--- a/awscfncli2/config/schema_v2.json
+++ b/awscfncli2/config/schema_v2.json
@@ -102,7 +102,7 @@
               {
                 "properties": {
                   "Extends": {
-                    "type": "string"
+                    "type":  ["string", "array" ]
                   },
                   "Order": {
                     "type": "integer"

--- a/tests/config/data/test.config.missing_blueprint.yaml
+++ b/tests/config/data/test.config.missing_blueprint.yaml
@@ -1,0 +1,20 @@
+Version: 2
+Blueprints:
+  Base:
+    Template: "test.template.yaml"
+    Region: "cn-east-1"
+    Profile: "ray"
+    Capabilities: [CAPABILITY_IAM]
+    Tags:
+      Project: 'demo'
+      Environment: 'dev'
+  Prod:
+    Region: "eu-west-1"
+    Profile: "prod"
+    Tags:
+      Environment: 'prod'   
+Stages:
+  Default:  
+    Vpc1:
+      Extends: [ 'Base', 'NonexistentBlueprint' ]
+

--- a/tests/config/data/test.config.yaml
+++ b/tests/config/data/test.config.yaml
@@ -8,6 +8,11 @@ Blueprints:
     Tags:
       Project: 'demo'
       Environment: 'dev'
+  Prod:
+    Region: "eu-west-1"
+    Profile: "prod"
+    Tags:
+      Environment: 'prod'   
 Stages:
   Staging:
     Vpc1:
@@ -33,3 +38,7 @@ Stages:
       Tags:
         Environment: 'prod'
         Department: 'cloud'
+  Prod:  
+    Vpc1:
+      Extends: [ 'Base', 'Prod' ]
+


### PR DESCRIPTION
This allows multiple blueprints to be specified in `Extends` clause as mentioned in #58. 
- It also maintains backward compatibility - JSON Schema is modified to allow both: `string` and `array` of elements. 
- Blueprints are applied in order of appearance. 
- I've added tests to cover the new functionality and updated docs in `README.md`.

Btw. there was something wrong with tests, as they tried to use `StackConfig` as a `dict` which it isn't. Fixed that one too ;-)