### PR TITLE
Change change set --confirm flag to --no-confirm

### DIFF
--- a/awscfncli2/cli/stack/sync.py
+++ b/awscfncli2/cli/stack/sync.py
@@ -10,14 +10,14 @@ from ...runner import StackSyncOptions, StackSyncCommand
 @stack.command()
 @click.option('--no-wait', '-w', is_flag=True, default=False,
               help='Exit immediately after ChangeSet is created.')
-@click.option('--confirm', is_flag=True, default=False,
-              help='Review changes before execute the ChangeSet')
+@click.option('--no-confirm', is_flag=True, default=False,
+              help='Do not wait for confirmation before executing the ChangeSet')
 @click.option('--use-previous-template', is_flag=True, default=False,
               help='Reuse the existing template that is associated with the '
                    'stack that you are updating.')
 @click.pass_context
 @command_exception_handler
-def sync(ctx, no_wait, confirm, use_previous_template):
+def sync(ctx, no_wait, no_confirm, use_previous_template):
     """Create and execute ChangeSets (SAM)
 
     Combines "aws cloudformation package" and "aws cloudformation deploy" command
@@ -29,7 +29,7 @@ def sync(ctx, no_wait, confirm, use_previous_template):
 
     options = StackSyncOptions(
         no_wait=no_wait,
-        confirm=confirm,
+        no_confirm=no_confirm,
         use_previous_template=use_previous_template,
     )
 

--- a/awscfncli2/runner/commands/stack_sync_command.py
+++ b/awscfncli2/runner/commands/stack_sync_command.py
@@ -10,7 +10,7 @@ from ...cli.utils import echo_pair
 
 class StackSyncOptions(namedtuple('StackSyncOptions',
                                   ['no_wait',
-                                   'confirm',
+                                   'no_confirm',
                                    'use_previous_template'])):
     pass
 
@@ -86,7 +86,7 @@ class StackSyncCommand(Command):
             self.ppt.secho('ChangeSet not executable.', fg='red')
             return
 
-        if self.options.confirm:
+        if not self.options.no_confirm:
             self.ppt.confirm('Do you want to execute ChangeSet?', abort=True)
 
         client_request_token = 'awscfncli-sync-{}'.format(uuid.uuid1())


### PR DESCRIPTION
Currently when using the sync option change-sets are produced but by default they are immediately applied with no ability to review the change-sets. The option `--confirm` exists but its optional and often will be forgotten about and thus stacks updated without time for review.

This seems counter intuitive to the purpose of change sets which exist so that safe, reviewed changes can be made. This PR reverses the flag - changing it to `--no-confirm` hence by default `cfn-cli stack sync` will wait for user confirmation before applying the change-set

Understand this may be a controversial PR but I honestly believe its the way 99% of users would expect change-sets to work. 