### PR TITLE
made ppt.confirm return the results from click.confirm

### DIFF
--- a/awscfncli2/cli/utils/pprint.py
+++ b/awscfncli2/cli/utils/pprint.py
@@ -66,7 +66,7 @@ class StackPrettyPrinter(object):
                   key_style=key_style, sep=sep)
 
     def confirm(self, *args, **argv):
-        click.confirm(*args, **argv)
+        return click.confirm(*args, **argv)
 
     def pprint_stack_name(self, qualified_name, stack_name, prefix=None):
         """Print stack qualified name"""


### PR DESCRIPTION
Just realized there is a bug in the previous PR - PrettyPrint.confirm doesn't return the results of click.confirm, so `self.ppt.confirm()` always returns None. I've updated it here.