### PR TITLE
Add disable-tail-events option to stack sync command

### DIFF
--- a/awscfncli2/cli/stack/sync.py
+++ b/awscfncli2/cli/stack/sync.py
@@ -15,11 +15,11 @@ from ...runner import StackSyncOptions, StackSyncCommand
 @click.option('--use-previous-template', is_flag=True, default=False,
               help='Reuse the existing template that is associated with the '
                    'stack that you are updating.')
-@click.option('--disable_describe_events', is_flag=True, default=False,
-              help='Disable tailing events to avoid throttling ')
+@click.option('--disable-tail-events', is_flag=True, default=False,
+              help='Disable tailing of cloudformation events')
 @click.pass_context
 @command_exception_handler
-def sync(ctx, no_wait, confirm, use_previous_template, disable_describe_events):
+def sync(ctx, no_wait, confirm, use_previous_template, disable_tail_events):
     """Create and execute ChangeSets (SAM)
 
     Combines "aws cloudformation package" and "aws cloudformation deploy" command
@@ -33,7 +33,7 @@ def sync(ctx, no_wait, confirm, use_previous_template, disable_describe_events):
         no_wait=no_wait,
         confirm=confirm,
         use_previous_template=use_previous_template,
-        disable_describe_events=disable_describe_events
+        disable_tail_events=disable_tail_events
     )
 
     command = StackSyncCommand(

--- a/awscfncli2/cli/stack/sync.py
+++ b/awscfncli2/cli/stack/sync.py
@@ -15,9 +15,11 @@ from ...runner import StackSyncOptions, StackSyncCommand
 @click.option('--use-previous-template', is_flag=True, default=False,
               help='Reuse the existing template that is associated with the '
                    'stack that you are updating.')
+@click.option('--disable_describe_events', is_flag=True, default=False,
+              help='Disable tailing events to avoid throttling ')
 @click.pass_context
 @command_exception_handler
-def sync(ctx, no_wait, confirm, use_previous_template):
+def sync(ctx, no_wait, confirm, use_previous_template, disable_describe_events):
     """Create and execute ChangeSets (SAM)
 
     Combines "aws cloudformation package" and "aws cloudformation deploy" command
@@ -31,6 +33,7 @@ def sync(ctx, no_wait, confirm, use_previous_template):
         no_wait=no_wait,
         confirm=confirm,
         use_previous_template=use_previous_template,
+        disable_describe_events=disable_describe_events
     )
 
     command = StackSyncCommand(

--- a/awscfncli2/cli/utils/pprint.py
+++ b/awscfncli2/cli/utils/pprint.py
@@ -320,8 +320,9 @@ class StackPrettyPrinter(object):
             else:
                 click.secho('      ' + line)
 
-    def wait_until_deploy_complete(self, session, stack):
-        start_tail_stack_events_daemon(session, stack, latest_events=0)
+    def wait_until_deploy_complete(self, session, stack, disable_tail_events=False):
+        if not disable_tail_events:
+            start_tail_stack_events_daemon(session, stack, latest_events=0)
 
         waiter = session.client('cloudformation').get_waiter(
             'stack_create_complete')
@@ -334,8 +335,9 @@ class StackPrettyPrinter(object):
             'stack_delete_complete')
         waiter.wait(StackName=stack.stack_id)
 
-    def wait_until_update_complete(self, session, stack):
-        start_tail_stack_events_daemon(session, stack)
+    def wait_until_update_complete(self, session, stack, disable_tail_events=False):
+        if not disable_tail_events:
+            start_tail_stack_events_daemon(session, stack)
 
         waiter = session.client('cloudformation').get_waiter(
             'stack_update_complete')

--- a/awscfncli2/runner/commands/stack_sync_command.py
+++ b/awscfncli2/runner/commands/stack_sync_command.py
@@ -12,7 +12,7 @@ class StackSyncOptions(namedtuple('StackSyncOptions',
                                   ['no_wait',
                                    'confirm',
                                    'use_previous_template',
-                                   'disable_describe_events'])):
+                                   'disable_tail_events'])):
     pass
 
 
@@ -105,9 +105,9 @@ class StackSyncCommand(Command):
             self.ppt.secho('ChangeSet execution started.')
         else:
             if is_new_stack:
-                self.ppt.wait_until_deploy_complete(session, stack, self.options.disable_describe_events)
+                self.ppt.wait_until_deploy_complete(session, stack, self.options.disable_tail_events)
             else:
-                self.ppt.wait_until_update_complete(session, stack, self.options.disable_describe_events)
+                self.ppt.wait_until_update_complete(session, stack, self.options.disable_tail_events)
             self.ppt.secho('ChangeSet execution complete.', fg='green')
 
 

--- a/awscfncli2/runner/commands/stack_sync_command.py
+++ b/awscfncli2/runner/commands/stack_sync_command.py
@@ -11,7 +11,8 @@ from ...cli.utils import echo_pair
 class StackSyncOptions(namedtuple('StackSyncOptions',
                                   ['no_wait',
                                    'confirm',
-                                   'use_previous_template'])):
+                                   'use_previous_template',
+                                   'disable_describe_events'])):
     pass
 
 
@@ -104,9 +105,9 @@ class StackSyncCommand(Command):
             self.ppt.secho('ChangeSet execution started.')
         else:
             if is_new_stack:
-                self.ppt.wait_until_deploy_complete(session, stack)
+                self.ppt.wait_until_deploy_complete(session, stack, self.options.disable_describe_events)
             else:
-                self.ppt.wait_until_update_complete(session, stack)
+                self.ppt.wait_until_update_complete(session, stack, self.options.disable_describe_events)
             self.ppt.secho('ChangeSet execution complete.', fg='green')
 
 


### PR DESCRIPTION
This relates to #68.

Added option to `stack sync` command to disable execution of `start_tail_stack_events_daemon` method to greatly reduce number of API calls made to cloudformation. 

I'm aware that this solution is rather easiest workaround but either way it might really help with throttling issue we experience during parallel stack deployment.