### PR TITLE
Global Config file and auto_deploy

### DIFF
--- a/awscfncli2/cli/context.py
+++ b/awscfncli2/cli/context.py
@@ -16,7 +16,8 @@ class ClickContext(object):
                  profile_name,
                  region_name,
                  artifact_store,
-                 pretty_printer):
+                 pretty_printer,
+                 global_settings):
         self._config_filename = config_filename
         self._stack_selector = StackSelector(stack_selector)
         self._boto3_profile = Boto3Profile(profile_name=profile_name,
@@ -25,6 +26,7 @@ class ClickContext(object):
         self._deployments = None
         self._pretty_printer = pretty_printer
         self._runner = None
+        self._global_settings = global_settings
 
         self._lock = threading.Lock()
 
@@ -32,7 +34,7 @@ class ClickContext(object):
     def config_filename(self):
         """Config file name"""
         return self._config_filename
-
+    
     @property
     def stack_selector(self):
         """Stack selector"""
@@ -74,3 +76,8 @@ class ClickContext(object):
     @property
     def ppt(self):
         return self._pretty_printer
+
+    @property
+    def global_settings(self):
+        return self._global_settings
+

--- a/awscfncli2/cli/main.py
+++ b/awscfncli2/cli/main.py
@@ -6,6 +6,7 @@ import logging
 import os
 import click
 import pkg_resources
+from configparser import SafeConfigParser
 
 from .context import ClickContext
 from .utils import StackPrettyPrinter
@@ -13,7 +14,7 @@ from .utils import StackPrettyPrinter
 VERSION = pkg_resources.require('awscfncli2')[0].version
 
 DEFAULT_CONFIG_FILE_NAMES = ['cfn-cli.yaml', 'cfn-cli.yml']
-
+DEFAULT_GLOBAL_CONFIG_FILE_NAME = '~/.cfn-cli/config'
 
 @click.group()
 @click.pass_context
@@ -89,7 +90,13 @@ def cfn_cli(ctx, file, stack, profile, region, artifact_store, verbose):
             file = os.path.join(base, fn)
             if os.path.exists(file) and os.path.isfile(file):
                 break
-
+            
+    # look for global config file
+    global_config_file = os.path.expanduser(DEFAULT_GLOBAL_CONFIG_FILE_NAME)
+    cp = SafeConfigParser()
+    if os.path.exists(global_config_file):
+        cp.read(global_config_file)
+        
     # Builds the context object
     ctx_obj = ClickContext(
         config_filename=file,
@@ -98,7 +105,7 @@ def cfn_cli(ctx, file, stack, profile, region, artifact_store, verbose):
         region_name=region,
         artifact_store = artifact_store,
         pretty_printer=StackPrettyPrinter(verbosity=verbose),
-
+        global_settings=cp
     )
 
     # Assign context object

--- a/awscfncli2/cli/stack/deploy.py
+++ b/awscfncli2/cli/stack/deploy.py
@@ -1,7 +1,6 @@
 #  -*- encoding: utf-8 -*-
 
 import click
-
 from . import stack
 from ..utils import command_exception_handler
 from ...cli import ClickContext
@@ -40,12 +39,19 @@ def deploy(ctx, no_wait, on_failure,
     """Deploy a new stack"""
     assert isinstance(ctx.obj, ClickContext)
 
+    try:    
+        auto_deploy = ctx.obj.global_settings.getboolean('behaviours', 'auto_deploy', fallback=False)
+    except Exception as ex:
+        ctx.obj.ppt.secho("Error processing Global Config file:\n " + str(ex), fg='red')
+        return
+
     options = StackDeployOptions(
         no_wait=no_wait,
         on_failure=on_failure,
         disable_rollback=disable_rollback,
         timeout_in_minutes=timeout_in_minutes,
-        ignore_existing=ignore_existing
+        ignore_existing=ignore_existing,
+        auto_deploy=auto_deploy
     )
 
     command = StackDeployCommand(

--- a/awscfncli2/runner/commands/stack_deploy_command.py
+++ b/awscfncli2/runner/commands/stack_deploy_command.py
@@ -2,7 +2,7 @@ import uuid
 from collections import namedtuple
 
 from .command import Command
-from .utils import is_stack_already_exists_exception
+from .utils import is_stack_already_exists_exception, is_stack_does_not_exist_exception
 
 
 class StackDeployOptions(
@@ -12,7 +12,8 @@ class StackDeployOptions(
                    'on_failure',
                    'disable_rollback',
                    'timeout_in_minutes',
-                   'ignore_existing'
+                   'ignore_existing',
+                   'auto_deploy'
                ])):
     pass
 
@@ -20,6 +21,10 @@ class StackDeployOptions(
 class StackDeployCommand(Command):
 
     def run(self, stack_context):
+        
+        if self.options.auto_deploy:
+            return self._auto_deploy(stack_context)
+        
         # stack contexts
         session = stack_context.session
         parameters = stack_context.parameters
@@ -70,4 +75,108 @@ class StackDeployCommand(Command):
         else:
             self.ppt.wait_until_deploy_complete(session, stack)
             self.ppt.secho('Stack deployment complete.', fg='green')
+            
+    def _auto_deploy(self, stack_context):
+        self.ppt.secho('Auto Deploy enabled', fg='yellow')
 
+        # stack contexts
+        session = stack_context.session
+        parameters = stack_context.parameters
+
+        # print qualified name
+        self.ppt.pprint_stack_name(stack_context.stack_key,
+                                   parameters['StackName'],
+                                   'Deploying stack ')
+
+        # create boto3 cfn resource
+        cfn = session.resource('cloudformation')
+        self.ppt.pprint_session(session)
+
+        # packaging if necessary
+        stack_context.run_packaging()
+
+        # overwrite using cli parameters
+        if self.options.on_failure is not None:
+            parameters['OnFailure'] = self.options.on_failure
+        if self.options.disable_rollback:
+            parameters['DisableRollback'] = self.options.disable_rollback
+        if self.options.timeout_in_minutes:
+            parameters['TimeoutInMinutes'] = self.options.timeout_in_minutes
+
+        self.ppt.pprint_parameters(parameters)
+
+        # calling boto3...
+        stack_name = parameters['StackName']
+        stack = cfn.Stack(stack_name)
+        stack_status = self._get_stack_status(stack)
+        if stack_status is None:
+            self._create_stack(cfn, stack_context)
+        elif stack_status == 'ROLLBACK_COMPLETE':
+            self.ppt.secho('Stack previously failed to create, and must be removed before recreation (status: ROLLBACK_COMPLETE).', fg='yellow')
+            self._delete_stack(cfn, stack_context)
+            self._create_stack(cfn, stack_context)
+        else:
+            self._update_stack(cfn, stack_context)
+
+    @staticmethod
+    def _get_stack_status(stack):
+        try:
+            status = stack.meta.client.describe_stacks(StackName=stack.name)
+        except Exception as ex:
+            if is_stack_does_not_exist_exception(ex):
+                return None
+            
+            raise
+        
+        return status['Stacks'][0]['StackStatus']
+
+    def _create_stack(self, cfn, stack_context):
+        # stack contexts
+        session = stack_context.session
+        parameters = stack_context.parameters
+
+        # calling boto3...
+        client_request_token = 'awscfncli-deploy-{}'.format(uuid.uuid1())
+        stack = cfn.create_stack(ClientRequestToken=client_request_token, **parameters)
+
+        self.ppt.pprint_stack(stack)
+
+        # wait until deployment is complete
+        self.ppt.wait_until_deploy_complete(session, stack)
+        self.ppt.secho('Stack deployment complete.', fg='green')
+            
+        return
+   
+    def _update_stack(self, cfn, stack_context):
+        # stack contexts
+        session = stack_context.session
+        parameters = stack_context.parameters
+
+        # calling boto3...
+        stack = cfn.Stack(parameters['StackName'])
+        stack.update(**parameters)
+
+        self.ppt.pprint_stack(stack)
+
+        # wait until deployment is complete
+        self.ppt.wait_until_update_complete(session, stack)
+        self.ppt.secho('Stack update complete.', fg='green')
+            
+        return
+
+    def _delete_stack(self, cfn, stack_context):
+        # stack contexts
+        session = stack_context.session
+        parameters = stack_context.parameters
+
+        # calling boto3...
+        stack = cfn.Stack(parameters['StackName'])
+        stack.delete()
+
+        self.ppt.pprint_stack(stack)
+
+        self.ppt.wait_until_delete_complete(session, stack)
+        self.ppt.secho('Stack delete complete.', fg='green')
+            
+        return
+        

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     'six>=1.10.0',
     'click>=6.0,<8',
     'PyYAML>=3.10,<4', # following awscli's requirements
-    'jsonschema>=2.6.0,<3',
+    'jsonschema>=2.6.0',
     'semantic_version>=2.0.0'
 ]
 


### PR DESCRIPTION
Hey, I wanted to see about creating functionality for 'stack deploy' which will more intelligently do the right thing based on the current stack status. I've added an "auto deploy" functionality which will either create, update, or delete and then create (ROLLBACK_COMPLETE). This will allow users to just use stack deploy without worrying about current state. I find this functionality super helpful during development.

In order to avoid changing behaviour unexpectedly, the new feature comes with a "global config" file (.ini format). The new feature is disabled by default, but if you create ~/.cfn-cli/config and set values accordingly, you can enable it:

**~/.cfn-cli/config:**
```
[behaviours]
auto_deploy = true
```

I think you might be working on similar functionality in v3, but I thought this might be a good way to make it available in v2. If you're open to the concept, I might have a few other improvements we can add through this paradigm (such as --confirm as default for stack sync).