### PR TITLE
Retry mechanism with exponential backoff on throttling errors

### DIFF
--- a/awscfncli2/cli/utils/common.py
+++ b/awscfncli2/cli/utils/common.py
@@ -1,0 +1,12 @@
+import botocore.exceptions
+
+
+def is_rate_limited_exception(e):
+    if isinstance(e, (botocore.exceptions.ClientError, botocore.exceptions.WaiterError)):
+        return 'Rate exceeded' in str(e)
+    else:
+        return False
+
+
+def is_not_rate_limited_exception(e):
+    return not is_rate_limited_exception(e)

--- a/awscfncli2/cli/utils/deco.py
+++ b/awscfncli2/cli/utils/deco.py
@@ -1,4 +1,3 @@
-import time
 import traceback
 from functools import wraps
 
@@ -30,35 +29,3 @@ def command_exception_handler(f):
             raise click.Abort
 
     return wrapper
-
-
-def retry_on_throttling(tries=4, delay=2, backoff=2):
-    """
-    Retries function on Throttling errors raised by WaiterError or ClientError
-
-    Args:
-        tries: number of attempts before raising any exceptions
-        delay: initial delay between retries in seconds
-        backoff: backoff multiplier e.g. value of 2 will double the delay each retry
-    """
-
-    def decorator_retry(f):
-        @wraps(f)
-        def f_retry(*args, **kwargs):
-            mtries, mdelay = tries, delay
-            while mtries > 1:
-                try:
-                    return f(*args, **kwargs)
-                except (botocore.exceptions.WaiterError, botocore.exceptions.ClientError) as e:
-                    if 'Rate exceeded' in str(e):
-                        click.secho(f"{str(e)}, Retrying in {mdelay} seconds...")
-                        time.sleep(mdelay)
-                        mtries -= 1
-                        mdelay *= backoff
-                    else:
-                        raise
-            return f(*args, **kwargs)
-
-        return f_retry
-
-    return decorator_retry

--- a/awscfncli2/cli/utils/deco.py
+++ b/awscfncli2/cli/utils/deco.py
@@ -1,4 +1,3 @@
-import logging
 import time
 import traceback
 from functools import wraps
@@ -7,8 +6,6 @@ import botocore.exceptions
 import click
 
 from awscfncli2.config import ConfigError
-
-logger = logging.getLogger(__name__)
 
 
 def command_exception_handler(f):
@@ -54,7 +51,7 @@ def retry_on_throttling(tries=4, delay=2, backoff=2):
                     return f(*args, **kwargs)
                 except (botocore.exceptions.WaiterError, botocore.exceptions.ClientError) as e:
                     if 'Rate exceeded' in str(e):
-                        logger.warning(f"{str(e)}, Retrying in {mdelay} seconds...")
+                        click.secho(f"{str(e)}, Retrying in {mdelay} seconds...")
                         time.sleep(mdelay)
                         mtries -= 1
                         mdelay *= backoff

--- a/awscfncli2/cli/utils/deco.py
+++ b/awscfncli2/cli/utils/deco.py
@@ -1,3 +1,5 @@
+import logging
+import time
 import traceback
 from functools import wraps
 
@@ -5,6 +7,8 @@ import botocore.exceptions
 import click
 
 from awscfncli2.config import ConfigError
+
+logger = logging.getLogger(__name__)
 
 
 def command_exception_handler(f):
@@ -29,3 +33,35 @@ def command_exception_handler(f):
             raise click.Abort
 
     return wrapper
+
+
+def retry_on_throttling(tries=4, delay=2, backoff=2):
+    """
+    Retries function on Throttling errors raised by WaiterError or ClientError
+
+    Args:
+        tries: number of attempts before raising any exceptions
+        delay: initial delay between retries in seconds
+        backoff: backoff multiplier e.g. value of 2 will double the delay each retry
+    """
+
+    def decorator_retry(f):
+        @wraps(f)
+        def f_retry(*args, **kwargs):
+            mtries, mdelay = tries, delay
+            while mtries > 1:
+                try:
+                    return f(*args, **kwargs)
+                except (botocore.exceptions.WaiterError, botocore.exceptions.ClientError) as e:
+                    if 'Rate exceeded' in str(e):
+                        logger.warning(f"{str(e)}, Retrying in {mdelay} seconds...")
+                        time.sleep(mdelay)
+                        mtries -= 1
+                        mdelay *= backoff
+                    else:
+                        raise
+            return f(*args, **kwargs)
+
+        return f_retry
+
+    return decorator_retry

--- a/awscfncli2/cli/utils/pprint.py
+++ b/awscfncli2/cli/utils/pprint.py
@@ -9,6 +9,7 @@ import yaml
 from .colormaps import CHANGESET_STATUS_TO_COLOR, CHANGESET_ACTION_TO_COLOR, \
     CHANGESET_REPLACEMENT_TO_COLOR, DRIFT_STATUS_TO_COLOR, \
     STACK_STATUS_TO_COLOR, CHANGESET_RESOURCE_REPLACEMENT_TO_COLOR
+from .deco import retry_on_throttling
 from .events import start_tail_stack_events_daemon
 from .pager import custom_paginator
 
@@ -321,6 +322,7 @@ class StackPrettyPrinter(object):
             else:
                 click.secho('      ' + line)
 
+    @retry_on_throttling(tries=5, delay=4, backoff=2)
     def wait_until_deploy_complete(self, session, stack, disable_tail_events=False):
         if not disable_tail_events:
             start_tail_stack_events_daemon(session, stack, latest_events=0)
@@ -329,6 +331,7 @@ class StackPrettyPrinter(object):
             'stack_create_complete')
         waiter.wait(StackName=stack.stack_id)
 
+    @retry_on_throttling(tries=5, delay=4, backoff=2)
     def wait_until_delete_complete(self, session, stack):
         start_tail_stack_events_daemon(session, stack)
 
@@ -336,6 +339,7 @@ class StackPrettyPrinter(object):
             'stack_delete_complete')
         waiter.wait(StackName=stack.stack_id)
 
+    @retry_on_throttling(tries=5, delay=4, backoff=2)
     def wait_until_update_complete(self, session, stack, disable_tail_events=False):
         if not disable_tail_events:
             start_tail_stack_events_daemon(session, stack)
@@ -344,11 +348,15 @@ class StackPrettyPrinter(object):
             'stack_update_complete')
         waiter.wait(StackName=stack.stack_id)
 
+    @retry_on_throttling(tries=5, delay=4, backoff=2)
     def wait_until_changset_complete(self, client, changeset_id):
         waiter = client.get_waiter('change_set_create_complete')
         try:
             waiter.wait(ChangeSetName=changeset_id)
         except botocore.exceptions.WaiterError as e:
+            if 'Rate exceeded' in str(e):
+                # change set might be created successfully but we got throttling error, retry is needed so rerasing exception
+                raise
             click.secho('ChangeSet create failed.', fg='red')
         else:
             click.secho('ChangeSet create complete.', fg='green')

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ install_requires = [
     'click~=7.0',
     'click_completion==0.5.2',
     'PyYAML<5.3,>=3.10', # Fix ERROR: awscli xxx has requirement PyYAML<5.3,>=3.10 , but you'll have pyyaml 5.3 which is incompatible.
-    'jsonschema>=2.6.0'
+    'jsonschema>=2.6.0',
+    'backoff'
 ]
 
 setup(


### PR DESCRIPTION
Currently when running large amounts of stacks in parallel cloudformation likes to throw throttling errors and it's not properly handled when running 'stack sync' as we might get plenty false negatives or wrong results for example:

- in function `check_changeset_type` when there's Throttling error it will automatically assume that's is 'CREATE' changeset type when in fact it should be 'UPDATE'

- in `wait_until_changset_complete` waiter when there's Throttling it will assume that ChangeSet create failed when creation might still be in progress

Solution is retry mechanism on methods that throws `Rate exceeded` errors. If it fails after given number of retires it will fail as usual. 

This handling of rate exceeded errors is crucial as we are getting them constantly in our CI/CD
