### PR TITLE
exit on no_wait & confirm

### DIFF
--- a/awscfncli2/runner/commands/stack_sync_command.py
+++ b/awscfncli2/runner/commands/stack_sync_command.py
@@ -88,6 +88,8 @@ class StackSyncCommand(Command):
             return
 
         if self.options.confirm:
+            if self.options.no_wait:
+                return 
             if not self.ppt.confirm('Do you want to execute ChangeSet?'):
                 return
 


### PR DESCRIPTION
I need the ability to create a change set without executing it or waiting for a user prompt, as I'm running this in a script. Currently there is no way to combine --no-wait with --confirm. 